### PR TITLE
fix: check if response exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "teamweek-button",
   "description": "Browser extensions for Toggl Plan",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "dependencies": {
     "@babel/runtime": "7.7.4",
     "ampersand-collection": "2.0.0",

--- a/src/api/billing.js
+++ b/src/api/billing.js
@@ -14,10 +14,10 @@ export async function getIsPremium(workspace) {
 
     default: {
       const plans = _.keyBy(await xhr('get', '/deadwood/v1/plans'), 'id');
-      const { plan_id } = await xhr(
+      const plan_id = await xhr(
         'get',
         `/deadwood/v1/${workspace.id}/subscription`
-      );
+      )?.plan_id;
       const plan = plans[plan_id];
       return !!plan && plan.member_limit > 5;
     }

--- a/src/manifest.chrome.v2.json
+++ b/src/manifest.chrome.v2.json
@@ -1,6 +1,6 @@
 {
   "name": "Toggl Plan: Project Planning Calendar",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "manifest_version": 2,
   "author": "Toggl <support@toggl.com>",
   "description": "Add tasks directly into Toggl Plan from your favourite web tools",

--- a/src/manifest.chrome.v3.json
+++ b/src/manifest.chrome.v3.json
@@ -1,6 +1,6 @@
 {
   "name": "Toggl Plan: Project Planning Calendar",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "manifest_version": 3,
   "author": "Toggl <support@toggl.com>",
   "description": "Add tasks directly into Toggl Plan from your favourite web tools",

--- a/src/manifest.firefox.v2.json
+++ b/src/manifest.firefox.v2.json
@@ -1,6 +1,6 @@
 {
   "name": "Toggl Plan: Project Planning Calendar",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "manifest_version": 2,
   "author": "Toggl <support@toggl.com>",
   "description": "Add tasks directly into Toggl Plan from your favourite web tools",

--- a/src/manifest.firefox.v3.json
+++ b/src/manifest.firefox.v3.json
@@ -1,6 +1,6 @@
 {
   "name": "Toggl Plan: Project Planning Calendar",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "manifest_version": 3,
   "author": "Toggl <support@toggl.com>",
   "description": "Add tasks directly into Toggl Plan from your favourite web tools",


### PR DESCRIPTION
Fixes:

<img width="1093" alt="Screenshot 2022-11-04 at 12 05 50 PM" src="https://user-images.githubusercontent.com/19775888/199907487-85249b2f-06e4-4576-bbaa-fd48c8fe3879.png">

which causes the browser extension to get stuck on the loading screen.