### PR TITLE
fix: don't open new window every time extension button is clicked

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "teamweek-button",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "teamweek-button",
   "description": "Browser extensions for Toggl Plan",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "dependencies": {
     "@babel/runtime": "7.7.4",
     "ampersand-collection": "2.0.0",

--- a/src/background/browser_action.js
+++ b/src/background/browser_action.js
@@ -5,11 +5,10 @@ import {
   createURL,
 } from './util';
 
-let windowId = false;
+let windowId = null;
 
 addOnExtensionClickListener(win => {
-  if (windowId === false) {
-    windowId = true;
+  if (windowId === null) {
     chrome.windows.create(
       {
         url: createURL({ name: '' }),
@@ -23,13 +22,13 @@ addOnExtensionClickListener(win => {
         windowId = win.id;
       }
     );
-  } else if (typeof windowId === 'number') {
+  } else {
     chrome.windows.update(windowId, { focused: true });
   }
 });
 
 addExtensionRemovedListener(winId => {
   if (windowId === winId) {
-    windowId = false;
+    windowId = null;
   }
 });

--- a/src/background/browser_action.js
+++ b/src/background/browser_action.js
@@ -1,15 +1,35 @@
 import config from 'src/api/config';
-import { addOnExtensionClickListener, createURL } from './util';
+import {
+  addExtensionRemovedListener,
+  addOnExtensionClickListener,
+  createURL,
+} from './util';
 
-addOnExtensionClickListener(function() {
-  chrome.windows.getCurrent({}, win => {
-    chrome.windows.create({
-      url: createURL({ name: '' }),
-      width: config.popup.width,
-      height: config.popup.height,
-      top: 120,
-      left: win.width - config.popup.width - 20,
-      type: 'popup',
-    });
-  });
+let windowId = false;
+
+addOnExtensionClickListener(win => {
+  if (windowId === false) {
+    windowId = true;
+    chrome.windows.create(
+      {
+        url: createURL({ name: '' }),
+        width: config.popup.width,
+        height: config.popup.height,
+        top: 120,
+        left: win.width - config.popup.width - 20,
+        type: 'popup',
+      },
+      win => {
+        windowId = win.id;
+      }
+    );
+  } else if (typeof windowId === 'number') {
+    chrome.windows.update(windowId, { focused: true });
+  }
+});
+
+addExtensionRemovedListener(winId => {
+  if (windowId === winId) {
+    windowId = false;
+  }
 });

--- a/src/background/util/index.js
+++ b/src/background/util/index.js
@@ -41,6 +41,10 @@ export function addOnExtensionClickListener(callback) {
   chrome.action.onClicked.addListener(callback);
 }
 
+export function addExtensionRemovedListener(callback) {
+  chrome.windows.onRemoved.addListener(callback);
+}
+
 export function executeScript(tabId, file) {
   if (getIsManifestV2()) {
     chrome.tabs.executeScript(tabId, { file });

--- a/src/manifest.chrome.v2.json
+++ b/src/manifest.chrome.v2.json
@@ -1,6 +1,6 @@
 {
   "name": "Toggl Plan: Project Planning Calendar",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "manifest_version": 2,
   "author": "Toggl <support@toggl.com>",
   "description": "Add tasks directly into Toggl Plan from your favourite web tools",

--- a/src/manifest.chrome.v3.json
+++ b/src/manifest.chrome.v3.json
@@ -1,6 +1,6 @@
 {
   "name": "Toggl Plan: Project Planning Calendar",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "manifest_version": 3,
   "author": "Toggl <support@toggl.com>",
   "description": "Add tasks directly into Toggl Plan from your favourite web tools",

--- a/src/manifest.firefox.v2.json
+++ b/src/manifest.firefox.v2.json
@@ -1,6 +1,6 @@
 {
   "name": "Toggl Plan: Project Planning Calendar",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "manifest_version": 2,
   "author": "Toggl <support@toggl.com>",
   "description": "Add tasks directly into Toggl Plan from your favourite web tools",

--- a/src/manifest.firefox.v3.json
+++ b/src/manifest.firefox.v3.json
@@ -1,6 +1,6 @@
 {
   "name": "Toggl Plan: Project Planning Calendar",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "manifest_version": 3,
   "author": "Toggl <support@toggl.com>",
   "description": "Add tasks directly into Toggl Plan from your favourite web tools",


### PR DESCRIPTION
**Current behaviour:**
A new popup is opened every time the browser extension button is clicked.

**New behaviour:**
Already opened popup is focused instead:

https://user-images.githubusercontent.com/19775888/201919754-43952f2b-2613-4c1d-b2fd-3bf78c581f09.mov

